### PR TITLE
Align Pac-Man rotation timing with the slide direction

### DIFF
--- a/src/pacman/renderers/svg.ts
+++ b/src/pacman/renderers/svg.ts
@@ -275,8 +275,8 @@ const generatePacManPositions = (store: StoreType): string[] => {
 
 const generatePacManRotations = (store: StoreType): string[] => {
 	const pivit = CELL_SIZE / 2;
-	return store.gameHistory.map((state) => {
-		switch (state.pacman.direction) {
+	const directionToRotation = (direction: 'right' | 'left' | 'up' | 'down'): string => {
+		switch (direction) {
 			case 'right':
 				return `0 ${pivit} ${pivit}`;
 			case 'left':
@@ -288,6 +288,16 @@ const generatePacManRotations = (store: StoreType): string[] => {
 			default:
 				return `0 ${pivit} ${pivit}`;
 		}
+	};
+	// Position interpolates linearly between snapshot[i] and snapshot[i+1]
+	// during interval i. The direction stored in snapshot[i+1] is the
+	// direction Pac-Man took during that move, so it must be displayed for
+	// the entire slide, not just at its end. Shift the rotation values one
+	// frame forward so the discrete keyframe at time keyTimes[i] holds the
+	// direction of the slide that begins there.
+	return store.gameHistory.map((_, i) => {
+		const lookaheadIndex = Math.min(i + 1, store.gameHistory.length - 1);
+		return directionToRotation(store.gameHistory[lookaheadIndex].pacman.direction);
 	});
 };
 


### PR DESCRIPTION
Follow-up to #9. After `calcMode="discrete"` was added to the rotation animateTransform, Pac-Man no longer sweeps through intermediate angles, but the keyframe timing still shows the wrong direction during each slide. This PR fixes the remaining timing offset.

## Problem

`generatePacManRotations` (`src/pacman/renderers/svg.ts:276-291`) associates each keyframe with `snapshot[i].pacman.direction`, which is the direction Pac-Man is facing **after** the move at frame `i` finished. Position uses linear interpolation, so during interval `i` the position slides from `snapshot[i]` to `snapshot[i+1]`. The direction shown over that slide should reflect `snapshot[i+1].pacman.direction` (the direction of that move), not `snapshot[i]`.

With the current timing, Pac-Man slides an entire cell while still facing his old direction, then snaps to the new direction only at arrival. Visually this reads as "the face is one cell behind the movement." Especially after #9 made the snap instantaneous, the lag is more noticeable than before because the eye expects the snap to align with the start of the new motion.

## Fix

Shift the rotation value array forward by one frame so the value shown during interval `i` is `snapshot[i+1].pacman.direction`. The last entry holds its previous value to keep the array length consistent with `gameHistory`.

```diff
 const generatePacManRotations = (store: StoreType): string[] => {
   const pivit = CELL_SIZE / 2;
-  return store.gameHistory.map((state) => {
-    switch (state.pacman.direction) {
+  const directionToRotation = (direction: 'right' | 'left' | 'up' | 'down'): string => {
+    switch (direction) {
       case 'right': return `0 ${pivit} ${pivit}`;
       case 'left':  return `180 ${pivit} ${pivit}`;
       case 'up':    return `270 ${pivit} ${pivit}`;
       case 'down':  return `90 ${pivit} ${pivit}`;
       default:      return `0 ${pivit} ${pivit}`;
     }
+  };
+  return store.gameHistory.map((_, i) => {
+    const lookaheadIndex = Math.min(i + 1, store.gameHistory.length - 1);
+    return directionToRotation(store.gameHistory[lookaheadIndex].pacman.direction);
   });
 };
```

After the change, the face flips at the start of each slide instead of the end, so movement and facing stay aligned cell-by-cell.

## Verification

- `pnpm run build` succeeds.
- The rotation value array remains `gameHistory.length` entries long, so the existing `generateChangingValuesAnimation` keyTime mapping is unaffected.