### PR TITLE
Smooth scared-ghost movement via trip-based fractional positions

### DIFF
--- a/src/pacman/core/game.ts
+++ b/src/pacman/core/game.ts
@@ -144,11 +144,6 @@ const updateGame = async (store: StoreType) => {
 		if (store.pacman.powerupRemainingDuration === 0) {
 			store.ghosts.forEach((g) => {
 				if (g.name === 'eyes') return;
-				// Only transition out of scared if the ghost is at a clean
-				// integer boundary. Ghosts in the middle of a half-step trip
-				// keep scared=true so moveScaredGhost can finish the trip
-				// before clearing the flag; otherwise subX/subY would be left
-				// at a fractional value with no code path to clean them up.
 				const atBoundary = (g.subX ?? 0) === 0 && (g.subY ?? 0) === 0;
 				if (atBoundary) {
 					g.scared = false;
@@ -240,9 +235,6 @@ const checkCollisions = (store: StoreType) => {
 				ghost.name = 'eyes';
 				ghost.scared = false;
 				ghost.target = { x: 26, y: 3 };
-				// Reset sub-positions: eyes return home at integer-step speed
-				// and any fractional offset would leave the eye sprite drawn
-				// half-cell off forever.
 				ghost.subX = 0;
 				ghost.subY = 0;
 				store.pacman.points += 10;

--- a/src/pacman/core/game.ts
+++ b/src/pacman/core/game.ts
@@ -143,7 +143,16 @@ const updateGame = async (store: StoreType) => {
 		store.pacman.powerupRemainingDuration--;
 		if (store.pacman.powerupRemainingDuration === 0) {
 			store.ghosts.forEach((g) => {
-				if (g.name !== 'eyes') g.scared = false;
+				if (g.name === 'eyes') return;
+				// Only transition out of scared if the ghost is at a clean
+				// integer boundary. Ghosts in the middle of a half-step trip
+				// keep scared=true so moveScaredGhost can finish the trip
+				// before clearing the flag; otherwise subX/subY would be left
+				// at a fractional value with no code path to clean them up.
+				const atBoundary = (g.subX ?? 0) === 0 && (g.subY ?? 0) === 0;
+				if (atBoundary) {
+					g.scared = false;
+				}
 			});
 			store.pacman.points = 0;
 		}
@@ -231,6 +240,11 @@ const checkCollisions = (store: StoreType) => {
 				ghost.name = 'eyes';
 				ghost.scared = false;
 				ghost.target = { x: 26, y: 3 };
+				// Reset sub-positions: eyes return home at integer-step speed
+				// and any fractional offset would leave the eye sprite drawn
+				// half-cell off forever.
+				ghost.subX = 0;
+				ghost.subY = 0;
 				store.pacman.points += 10;
 				store.pacman.ghostsEaten = (store.pacman.ghostsEaten ?? 0) + 1;
 			} else {

--- a/src/pacman/movement/ghosts-movement.ts
+++ b/src/pacman/movement/ghosts-movement.ts
@@ -191,9 +191,68 @@ const moveGhostToScatterTarget = (ghost: Ghost, store: StoreType) => {
 	}
 };
 
-// When scared, ghosts move randomly but with some intelligence
+// When scared, ghosts move smoothly at half speed.
+//
+// Design: trip-based commitment. A "trip" is a 1-cell move that takes 2 frames
+// (0.5 cells per frame). AI direction decisions only happen at integer cell
+// boundaries (subX === 0 AND subY === 0). Mid-trip, the ghost continues in
+// the committed direction. This avoids two issues that the naive 0.5-per-frame
+// approach produces:
+//   - Direction oscillation at the AI layer leaves ghost wobbling between
+//     0 and 0.5 forever.
+//   - Powerup ending mid-trip leaves subX/subY at a fractional value that
+//     never gets cleared by non-scared movement code paths.
+//
+// When the powerup duration hits 0 (handled in game.ts updateGame), boundary
+// ghosts get scared=false immediately. Mid-trip ghosts stay scared and finish
+// their trip here, then transition out of scared at the next boundary.
 const moveScaredGhost = (ghost: Ghost, store: StoreType) => {
-	// Check if you already have a target or if you have already reached the current target
+	const SCARED_SPEED = 0.5;
+	const subX = ghost.subX ?? 0;
+	const subY = ghost.subY ?? 0;
+	const atBoundary = subX === 0 && subY === 0;
+
+	if (!atBoundary) {
+		// Mid-trip: keep moving in the direction we started in.
+		// Direction is encoded in the sign of subX / subY.
+		const dirX = subX > 0 ? 1 : subX < 0 ? -1 : 0;
+		const dirY = subY > 0 ? 1 : subY < 0 ? -1 : 0;
+		ghost.subX = subX + dirX * SCARED_SPEED;
+		ghost.subY = subY + dirY * SCARED_SPEED;
+		if ((ghost.subX ?? 0) >= 1) {
+			ghost.x += 1;
+			ghost.subX = 0;
+		} else if ((ghost.subX ?? 0) <= -1) {
+			ghost.x -= 1;
+			ghost.subX = 0;
+		}
+		if ((ghost.subY ?? 0) >= 1) {
+			ghost.y += 1;
+			ghost.subY = 0;
+		} else if ((ghost.subY ?? 0) <= -1) {
+			ghost.y -= 1;
+			ghost.subY = 0;
+		}
+		// Trip just completed (we landed on an integer boundary). If the
+		// powerup has expired, transition out of scared mode now so the
+		// snapshot for this frame captures the clean handoff.
+		const nowAtBoundary = (ghost.subX ?? 0) === 0 && (ghost.subY ?? 0) === 0;
+		if (nowAtBoundary && store.pacman.powerupRemainingDuration === 0) {
+			ghost.scared = false;
+		}
+		return;
+	}
+
+	// At integer boundary. If the powerup has ended (we got here because
+	// updateGame left scared=true while waiting for trip completion), finish
+	// the transition. This branch covers the rare case where the boundary
+	// ghost reached this point through some other path.
+	if (store.pacman.powerupRemainingDuration === 0) {
+		ghost.scared = false;
+		return;
+	}
+
+	// Else: AI picks a new direction for the next trip.
 	if (!ghost.target || (ghost.x === ghost.target.x && ghost.y === ghost.target.y)) {
 		ghost.target = getRandomDestination(ghost.x, ghost.y);
 	}
@@ -201,44 +260,33 @@ const moveScaredGhost = (ghost: Ghost, store: StoreType) => {
 	const validMoves = getValidMovesWithoutReverse(ghost);
 	if (validMoves.length === 0) return;
 
-	// Move toward target but with some randomness to appear "scared"
 	const dx = ghost.target.x - ghost.x;
 	const dy = ghost.target.y - ghost.y;
-
-	// Filter moves that generally go toward the target but with randomness
 	let possibleMoves = validMoves;
-
-	// 50% chance to choose a completely random move
 	if (Math.random() < 0.5) {
-		// Choose any valid move
+		// Random direction
 	} else {
-		// Try to choose a move that goes in the direction of the target.
 		const goodMoves = validMoves.filter((move) => {
 			const moveX = move[0];
 			const moveY = move[1];
 			return (dx > 0 && moveX > 0) || (dx < 0 && moveX < 0) || (dy > 0 && moveY > 0) || (dy < 0 && moveY < 0);
 		});
-
-		// If there are "good" moves, use them.
 		if (goodMoves.length > 0) {
 			possibleMoves = goodMoves;
 		}
 	}
 
-	// Choose a random move from the possible moves
 	const [moveX, moveY] = possibleMoves[Math.floor(Math.random() * possibleMoves.length)];
 
-	// If Pacman has power-up, ghosts move slower (60% slower)
-	if (store.pacman.powerupRemainingDuration && Math.random() < 0.6) return;
-
-	// Update ghost direction based on movement
 	if (moveX > 0) ghost.direction = 'right';
 	else if (moveX < 0) ghost.direction = 'left';
 	else if (moveY > 0) ghost.direction = 'down';
 	else if (moveY < 0) ghost.direction = 'up';
 
-	ghost.x += moveX;
-	ghost.y += moveY;
+	// Start a new trip: take the first half-step. The next frame this
+	// function runs, the mid-trip branch above will finish the trip.
+	ghost.subX = moveX * SCARED_SPEED;
+	ghost.subY = moveY * SCARED_SPEED;
 };
 
 // Function to get valid moves that are not reversals of the current direction

--- a/src/pacman/movement/ghosts-movement.ts
+++ b/src/pacman/movement/ghosts-movement.ts
@@ -191,30 +191,15 @@ const moveGhostToScatterTarget = (ghost: Ghost, store: StoreType) => {
 	}
 };
 
-// When scared, ghosts move smoothly at half speed.
-//
-// Design: trip-based commitment. A "trip" is a 1-cell move that takes 2 frames
-// (0.5 cells per frame). AI direction decisions only happen at integer cell
-// boundaries (subX === 0 AND subY === 0). Mid-trip, the ghost continues in
-// the committed direction. This avoids two issues that the naive 0.5-per-frame
-// approach produces:
-//   - Direction oscillation at the AI layer leaves ghost wobbling between
-//     0 and 0.5 forever.
-//   - Powerup ending mid-trip leaves subX/subY at a fractional value that
-//     never gets cleared by non-scared movement code paths.
-//
-// When the powerup duration hits 0 (handled in game.ts updateGame), boundary
-// ghosts get scared=false immediately. Mid-trip ghosts stay scared and finish
-// their trip here, then transition out of scared at the next boundary.
+// When scared, ghosts move randomly but with some intelligence
 const moveScaredGhost = (ghost: Ghost, store: StoreType) => {
+	// Ghosts move at half speed during power-up (one cell per two frames)
 	const SCARED_SPEED = 0.5;
 	const subX = ghost.subX ?? 0;
 	const subY = ghost.subY ?? 0;
 	const atBoundary = subX === 0 && subY === 0;
 
 	if (!atBoundary) {
-		// Mid-trip: keep moving in the direction we started in.
-		// Direction is encoded in the sign of subX / subY.
 		const dirX = subX > 0 ? 1 : subX < 0 ? -1 : 0;
 		const dirY = subY > 0 ? 1 : subY < 0 ? -1 : 0;
 		ghost.subX = subX + dirX * SCARED_SPEED;
@@ -233,9 +218,6 @@ const moveScaredGhost = (ghost: Ghost, store: StoreType) => {
 			ghost.y -= 1;
 			ghost.subY = 0;
 		}
-		// Trip just completed (we landed on an integer boundary). If the
-		// powerup has expired, transition out of scared mode now so the
-		// snapshot for this frame captures the clean handoff.
 		const nowAtBoundary = (ghost.subX ?? 0) === 0 && (ghost.subY ?? 0) === 0;
 		if (nowAtBoundary && store.pacman.powerupRemainingDuration === 0) {
 			ghost.scared = false;
@@ -243,16 +225,12 @@ const moveScaredGhost = (ghost: Ghost, store: StoreType) => {
 		return;
 	}
 
-	// At integer boundary. If the powerup has ended (we got here because
-	// updateGame left scared=true while waiting for trip completion), finish
-	// the transition. This branch covers the rare case where the boundary
-	// ghost reached this point through some other path.
 	if (store.pacman.powerupRemainingDuration === 0) {
 		ghost.scared = false;
 		return;
 	}
 
-	// Else: AI picks a new direction for the next trip.
+	// Check if you already have a target or if you have already reached the current target
 	if (!ghost.target || (ghost.x === ghost.target.x && ghost.y === ghost.target.y)) {
 		ghost.target = getRandomDestination(ghost.x, ghost.y);
 	}
@@ -260,31 +238,39 @@ const moveScaredGhost = (ghost: Ghost, store: StoreType) => {
 	const validMoves = getValidMovesWithoutReverse(ghost);
 	if (validMoves.length === 0) return;
 
+	// Move toward target but with some randomness to appear "scared"
 	const dx = ghost.target.x - ghost.x;
 	const dy = ghost.target.y - ghost.y;
+
+	// Filter moves that generally go toward the target but with randomness
 	let possibleMoves = validMoves;
+
+	// 50% chance to choose a completely random move
 	if (Math.random() < 0.5) {
-		// Random direction
+		// Choose any valid move
 	} else {
+		// Try to choose a move that goes in the direction of the target.
 		const goodMoves = validMoves.filter((move) => {
 			const moveX = move[0];
 			const moveY = move[1];
 			return (dx > 0 && moveX > 0) || (dx < 0 && moveX < 0) || (dy > 0 && moveY > 0) || (dy < 0 && moveY < 0);
 		});
+
+		// If there are "good" moves, use them.
 		if (goodMoves.length > 0) {
 			possibleMoves = goodMoves;
 		}
 	}
 
+	// Choose a random move from the possible moves
 	const [moveX, moveY] = possibleMoves[Math.floor(Math.random() * possibleMoves.length)];
 
+	// Update ghost direction based on movement
 	if (moveX > 0) ghost.direction = 'right';
 	else if (moveX < 0) ghost.direction = 'left';
 	else if (moveY > 0) ghost.direction = 'down';
 	else if (moveY < 0) ghost.direction = 'up';
 
-	// Start a new trip: take the first half-step. The next frame this
-	// function runs, the mid-trip branch above will finish the trip.
 	ghost.subX = moveX * SCARED_SPEED;
 	ghost.subY = moveY * SCARED_SPEED;
 };

--- a/src/pacman/renderers/svg.ts
+++ b/src/pacman/renderers/svg.ts
@@ -311,8 +311,10 @@ const generateGhostPositions = (store: StoreType, ghostIndex: number): string[] 
 			return '0,0'; // Default value for cases where the ghost does not exist
 		}
 		const ghost = state.ghosts[ghostIndex];
-		const x = ghost.x * (CELL_SIZE + GAP_SIZE);
-		const y = ghost.y * (CELL_SIZE + GAP_SIZE) + 15;
+		const fx = ghost.x + (ghost.subX ?? 0);
+		const fy = ghost.y + (ghost.subY ?? 0);
+		const x = fx * (CELL_SIZE + GAP_SIZE);
+		const y = fy * (CELL_SIZE + GAP_SIZE) + 15;
 		return `${x},${y}`;
 	});
 };

--- a/src/pacman/types.ts
+++ b/src/pacman/types.ts
@@ -41,6 +41,8 @@ export interface Ghost {
 	respawnCounter: number;
 	freezeCounter: number;
 	justReleasedFromHouse: boolean;
+	subX?: number;
+	subY?: number;
 }
 
 /* ───────────────────────── Store ───────────────────────────── */


### PR DESCRIPTION
Per the review feedback that the original accumulator only addresses the variance and not the underlying stop-and-go, this PR switches to trip-based smooth movement.

## What changed

- Add optional `subX` / `subY` floats to `Ghost`. Logical `x` / `y` stay integer so BFS, collision detection, and grid lookups are unchanged.
- In `moveScaredGhost`, the AI picks a direction only at integer boundaries (`subX === 0 && subY === 0`). The ghost then commits to a 2-frame trip that moves 0.5 cells per frame. Mid-trip the AI cannot reverse, which removes wobble caused by direction noise.
- When the powerup duration hits 0, ghosts at a boundary transition to `scared=false` immediately. Ghosts mid-trip stay `scared=true` until the trip completes, so `subX` / `subY` are guaranteed to be `0` whenever `scared` is cleared.
- When a scared ghost is eaten, `checkCollisions` resets its `subX` / `subY` to `0` along with switching to eyes.
- The SVG renderer adds `(subX, subY)` to `(x, y)` when emitting position values, so position interpolation produces continuous half-cell slides instead of stop-and-go.

## Properties

- Average speed during powerup: 50% of normal speed (one cell per two frames).
- Max consecutive frames at a fractional position per ghost: **1** (the natural mid-trip state, never permanent). Verified numerically on real contribution data.
- Other movement functions (chase, scatter, eyes return, in-house) are unchanged and continue to use integer-step movement.

## Open question

Average speed is 50%, not the 40% (= 60% slower) that the original comment described. Happy to switch to 0.4 per frame with a Bresenham-style accumulator inside the trip if you'd rather match the original number exactly. 50% matches the arcade reference for scared ghosts which is why I picked it.