### PR TITLE
Patrol around scatter corner instead of freezing

### DIFF
--- a/src/pacman/movement/ghosts-movement.ts
+++ b/src/pacman/movement/ghosts-movement.ts
@@ -180,6 +180,21 @@ const moveGhostToScatterTarget = (ghost: Ghost, store: StoreType) => {
 	const target = SCATTER_CORNERS[ghost.name] || SCATTER_CORNERS['blinky'];
 	ghost.target = target;
 
+	// At the corner, step to an adjacent cell so BFS loops the ghost back next frame
+	if (ghost.x === target.x && ghost.y === target.y) {
+		const moves = MovementUtils.getValidMoves(ghost.x, ghost.y);
+		if (moves.length > 0) {
+			const [dx, dy] = moves[0];
+			ghost.x += dx;
+			ghost.y += dy;
+			if (dx > 0) ghost.direction = 'right';
+			else if (dx < 0) ghost.direction = 'left';
+			else if (dy > 0) ghost.direction = 'down';
+			else if (dy < 0) ghost.direction = 'up';
+		}
+		return;
+	}
+
 	const nextMove = BFSTargetLocation(ghost.x, ghost.y, target.x, target.y, ghost.direction);
 	if (nextMove) {
 		ghost.x = nextMove.x;


### PR DESCRIPTION
Follow-up from the side note on #13.

In scatter mode, ghosts reach their `SCATTER_CORNERS` cell and stop, because `BFSTargetLocation` returns null when the start equals the target. When chase mode kicks in, all four ghosts rush from the corners toward Pac-Man at once.

## Approach

I kept `SCATTER_CORNERS` where they are and added a small patrol branch at the top of `moveGhostToScatterTarget`: when the ghost is already at the corner cell, step to an adjacent valid cell. The next frame, BFS pulls the ghost back to the corner, which forms a small loop instead of stopping.

Not a perfect replica of the arcade (the arcade uses an unreachable target plus per-frame greedy direction choice; here the loop emerges from BFS round-tripping a 1-cell offset), but it solves the visible problem and keeps the change local to `moveGhostToScatterTarget`. No map / wall changes, no `BFSTargetLocation` semantics changes for other callers.

## Verification

Tested locally with `cli/cli.js` on my contribution data. During scatter mode, ghosts now circle a small loop near their corners instead of standing still until the mode switch.