### PR TITLE
Reset ghost mode state at the start of each game

### DIFF
--- a/src/pacman/core/game.ts
+++ b/src/pacman/core/game.ts
@@ -96,6 +96,7 @@ const startGame = async (store: StoreType) => {
 	store.aliveSteps = 0;
 	store.gameHistory = [];
 	store.ghosts.forEach((g) => (g.scared = false));
+	GhostsMovement.resetGameMode();
 
 	store.grid = Utils.createGridFromData(store);
 

--- a/src/pacman/movement/ghosts-movement.ts
+++ b/src/pacman/movement/ghosts-movement.ts
@@ -17,6 +17,12 @@ let currentMode = 'scatter';
 let modeTimer = 0;
 let dotsRemaining = 0;
 
+const resetGameMode = () => {
+	currentMode = 'scatter';
+	modeTimer = 0;
+	dotsRemaining = 0;
+};
+
 const moveGhosts = (store: StoreType) => {
 	// Calculate the total number of points remaining to define the behavior
 	dotsRemaining = countRemainingDots(store);
@@ -638,5 +644,6 @@ const getRandomDestination = (x: number, y: number) => {
 };
 
 export const GhostsMovement = {
-	moveGhosts
+	moveGhosts,
+	resetGameMode
 };


### PR DESCRIPTION
The module-level \`currentMode\` and \`modeTimer\` in \`ghosts-movement.ts\` are never reset, so when a host process instantiates more than one \`PacmanRenderer\` (e.g. the \`index.html\` demo page when you press Generate a second time), the second game inherits whatever mode and timer the first game ended on. The same seed and same username then produce a different game.

Adding \`resetGameMode()\` to \`startGame\` restores per-game isolation. Measured on \`abozanona\` and \`torvalds\` across all three player styles, running two games back to back in the same process:

- Without the fix: run1 != run2 in all 6 scenarios (mode state leaks).
- With the fix: run1 == run2 in all 6 scenarios.

Total deaths in the second back-to-back game also drop from 24 to 15 (-37%), since the leaked \`chase\` state was making ghosts attack immediately on game 2.

The CLI / GitHub Action use a fresh process per invocation so they are not affected, but library consumers and the demo page are.