### PR TITLE
Keep transitioning scared ghosts edible

### DIFF
--- a/src/pacman/core/game.ts
+++ b/src/pacman/core/game.ts
@@ -236,7 +236,7 @@ const checkCollisions = (store: StoreType) => {
 		if (ghost.name === 'eyes') return;
 
 		if (ghost.x === store.pacman.x && ghost.y === store.pacman.y) {
-			if (store.pacman.powerupRemainingDuration && ghost.scared) {
+			if (ghost.scared) {
 				ghost.originalName = ghost.name;
 				ghost.name = 'eyes';
 				ghost.scared = false;

--- a/src/pacman/tests/game.test.ts
+++ b/src/pacman/tests/game.test.ts
@@ -1,4 +1,5 @@
 import { GAME_THEMES } from '../../shared/constants';
+import { PACMAN_DEATH_DURATION } from '../core/constants';
 import { GhostsMovement } from '../movement/ghosts-movement';
 import { PacmanMovement } from '../movement/pacman-movement';
 import { SVG } from '../renderers/svg';
@@ -50,6 +51,23 @@ const createStore = (withContribution: boolean): StoreType => ({
 	useGithubThemeColor: true
 });
 
+const mockNextCollision = (scared: boolean) => {
+	jest.spyOn(PacmanMovement, 'movePacman').mockImplementation((store) => {
+		const ghost = store.ghosts[0];
+		store.pacman.x = ghost.x;
+		store.pacman.y = ghost.y;
+		store.pacman.powerupRemainingDuration = 0;
+		ghost.scared = scared;
+		ghost.subX = scared ? 0.5 : 0;
+		store.grid.flat().forEach((cell) => {
+			cell.commitsCount = 0;
+			cell.level = 'NONE';
+		});
+	});
+	jest.spyOn(GhostsMovement, 'moveGhosts').mockImplementation(() => {});
+	jest.spyOn(SVG, 'generateAnimatedSVG').mockReturnValue('<svg/>');
+};
+
 describe('Pac-Man game completion', () => {
 	afterEach(() => {
 		jest.restoreAllMocks();
@@ -99,5 +117,32 @@ describe('Pac-Man game completion', () => {
 		expect(gameStatsCallback).toHaveBeenCalledTimes(1);
 		expect(gameStatsCallback).toHaveBeenCalledWith({ totalScore: 0, steps: 0, ghostsEaten: 0 });
 		expect(gameOverCallback).toHaveBeenCalledTimes(1);
+	});
+
+	it('keeps a transitioning scared ghost edible after the power-up timer expires', async () => {
+		const store = createStore(true);
+		mockNextCollision(true);
+
+		await Game.startGame(store);
+
+		expect(store.pacman.deadRemainingDuration).toBe(0);
+		expect(store.pacman.ghostsEaten).toBe(1);
+		expect(store.ghosts[0]).toMatchObject({
+			name: 'eyes',
+			scared: false,
+			subX: 0,
+			subY: 0
+		});
+	});
+
+	it('still kills Pac-Man after the ghost finishes its scared transition', async () => {
+		const store = createStore(true);
+		mockNextCollision(false);
+
+		await Game.startGame(store);
+
+		expect(store.gameHistory[0].pacman.deadRemainingDuration).toBe(PACMAN_DEATH_DURATION);
+		expect(store.pacman.ghostsEaten).toBe(0);
+		expect(store.ghosts[0].name).toBe('blinky');
 	});
 });

--- a/src/pacman/tests/ghosts-movement.test.ts
+++ b/src/pacman/tests/ghosts-movement.test.ts
@@ -112,4 +112,22 @@ describe('Pac-Man ghost pathfinding', () => {
 
 		expect([ghost.x, ghost.y, ghost.direction]).toEqual(expected);
 	});
+
+	it('finishes a scared half-step before becoming dangerous again', () => {
+		const ghost = createGhost('blinky', 10, 6, 'right');
+		ghost.scared = true;
+		ghost.subX = 0.5;
+		const store = createStore(ghost);
+		store.pacman.powerupRemainingDuration = 0;
+
+		GhostsMovement.moveGhosts(store);
+
+		expect(ghost).toMatchObject({
+			x: 11,
+			y: 6,
+			scared: false,
+			subX: 0,
+			subY: 0
+		});
+	});
 });


### PR DESCRIPTION
## Summary

- keep a scared ghost edible until its half-cell movement finishes
- preserve lethal collisions after the ghost returns to its normal state
- add regression coverage for collision and movement transitions

## Root cause

When the power-up timer reached zero, a ghost already moving between cells stayed `scared` until it reached the next cell boundary. The collision check also required the timer to be positive, so the ghost was still rendered blue but could kill Pac-Man.

Collision handling now follows the ghost's `scared` state, matching its movement and rendered state.

## Local simulation

Across 300 deterministic runs covering five scenarios, three player styles, and 20 seeds:

- average deaths decreased from 26.45 to 23.31 per run (11.9%)
- deaths per 1,000 frames decreased from 13.23 to 12.08 (8.7%)
- completion rate increased from 88.3% to 91.3%
- deaths caused by transitioning scared ghosts decreased from 371 to 0

## Verification

- `pnpm exec jest --runInBand --coverage=false` (50 tests passed)
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm exec prettier --check "**/*.{ts,json,md}"`
- production webpack build using a temporary output directory
