### PR TITLE
Migrate GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/pipeline_check.yml
+++ b/.github/workflows/pipeline_check.yml
@@ -12,10 +12,10 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@v5
 
             - name: Install dependencies
               run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,18 +23,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
       - name: Install root dependencies
         run: pnpm install --frozen-lockfile
@@ -87,7 +88,7 @@ jobs:
           git push origin main --follow-tags
 
       - name: Create GitHub Release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.repos.createRelease({

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'Generates arcade games from a GitHub user contributions grid and o
 author: 'abozanona'
 
 runs:
-    using: node20
+    using: node24
     main: github-action/dist/index.js
 
 inputs:

--- a/github-action/action.yml
+++ b/github-action/action.yml
@@ -3,7 +3,7 @@ description: 'Generates arcade games from a GitHub user contributions grid and o
 author: 'abozanona'
 
 runs:
-    using: node20
+    using: node24
     main: dist/index.js
 
 inputs:


### PR DESCRIPTION
## Summary

- run both JavaScript action entry points on Node.js 24
- use Node.js 24-compatible action versions in the pipeline and release workflows
- build and publish releases with Node.js 24 while keeping package-manager caching disabled

## Why

Node.js 20 has reached end of life, and GitHub Actions runners now default JavaScript actions to Node.js 24. Updating the action metadata and workflow dependencies removes the Node.js 20 deprecation warnings and makes the supported runtime explicit.

No action inputs, outputs, or bundle paths change.

Closes #27

## Validation

- installed root and action dependencies from their frozen lockfiles with Node.js 24.18.0 and pnpm 9.15.4
- built the root package and GitHub Action bundle with Node.js 24
- verified the committed Action bundle is unchanged and parses under Node.js 24
- ran an Action runtime smoke test under Node.js 24
- passed Prettier, YAML parsing, `actionlint`, and `git diff --check`
- ran the full test suite; 47 of 51 tests passed, and the four existing date-boundary failures reproduced unchanged on Node.js 20 and are being handled separately
