### PR TITLE
Fix Sunday contribution grid boundary

### DIFF
--- a/src/shared/utils/utils.test.ts
+++ b/src/shared/utils/utils.test.ts
@@ -1,0 +1,47 @@
+import { GAME_THEMES, GRID_WIDTH } from '../constants';
+import type { BaseStore } from '../types';
+import { Utils } from './utils';
+
+const SUNDAY = new Date('2026-07-26T12:00:00.000Z');
+
+const createStore = (): BaseStore => ({
+	config: {
+		platform: 'github',
+		username: 'test-user',
+		gameTheme: 'github',
+		svgCallback: jest.fn(),
+		gameOverCallback: jest.fn(),
+		pointsIncreasedCallback: jest.fn()
+	},
+	contributions: [
+		{
+			date: SUNDAY,
+			count: 3,
+			color: GAME_THEMES.github.intensityColors[2],
+			level: 'SECOND_QUARTILE'
+		}
+	],
+	grid: [],
+	monthLabels: []
+});
+
+describe('buildGrid', () => {
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('includes a current-day contribution when the grid ends on Sunday', () => {
+		jest.useFakeTimers();
+		jest.setSystemTime(SUNDAY);
+		const store = createStore();
+
+		Utils.buildGrid(store);
+
+		expect(store.grid).toHaveLength(GRID_WIDTH);
+		expect(store.grid[GRID_WIDTH - 1][0]).toEqual({
+			commitsCount: 3,
+			color: GAME_THEMES.github.intensityColors[2],
+			level: 'SECOND_QUARTILE'
+		});
+	});
+});

--- a/src/shared/utils/utils.ts
+++ b/src/shared/utils/utils.ts
@@ -23,6 +23,12 @@ const getGridEndDate = (store: BaseStore) => {
 	return endDate;
 };
 
+const getGridStartDate = (endDate: Date) => {
+	const startDate = new Date(endDate);
+	startDate.setUTCDate(endDate.getUTCDate() - (GRID_WIDTH - 1) * 7 - endDate.getUTCDay());
+	return startDate;
+};
+
 /* ───────────────────────── Theme helpers ────────────────────── */
 export const getCurrentTheme = (store: BaseStore): GameTheme => GAME_THEMES[store.config.gameTheme] ?? GAME_THEMES['github'];
 
@@ -54,12 +60,9 @@ export const calculateContributionLevel = (contribution: number, maxContribution
 
 export const buildGrid = (store: BaseStore) => {
 	const endDate = getGridEndDate(store);
-	const startDate = new Date(endDate);
-	startDate.setUTCDate(endDate.getUTCDate() - 365);
-	startDate.setUTCDate(startDate.getUTCDate() - startDate.getUTCDay());
+	const startDate = getGridStartDate(endDate);
 
-	const realWidth = 53;
-	const grid = Array.from({ length: realWidth }, () =>
+	const grid = Array.from({ length: GRID_WIDTH }, () =>
 		Array.from({ length: GRID_HEIGHT }, () => ({
 			commitsCount: 0,
 			color: getCurrentTheme(store).intensityColors[0],
@@ -74,7 +77,7 @@ export const buildGrid = (store: BaseStore) => {
 		const day = date.getUTCDay();
 		const week = weeksBetween(startDate, date);
 
-		if (week >= 0 && week < realWidth) {
+		if (week >= 0 && week < GRID_WIDTH) {
 			const theme = getCurrentTheme(store);
 			grid[week][day] = {
 				commitsCount: c.count,
@@ -89,9 +92,7 @@ export const buildGrid = (store: BaseStore) => {
 
 export const buildMonthLabels = (store: BaseStore) => {
 	const endDate = getGridEndDate(store);
-	const startDate = new Date(endDate);
-	startDate.setUTCDate(endDate.getUTCDate() - 365);
-	startDate.setUTCDate(startDate.getUTCDate() - startDate.getUTCDay());
+	const startDate = getGridStartDate(endDate);
 
 	const realWidth = weeksBetween(startDate, endDate) + 1;
 	const labels = Array(realWidth).fill('');


### PR DESCRIPTION
## Summary

- calculate the 53-week grid start from the grid width and end-date weekday
- share the same start date between the contribution grid and month labels
- add a regression test for a contribution on the current UTC Sunday

## Root cause

The previous calculation subtracted 365 days and then rounded backward to Sunday. When the grid ended on Sunday, the current contribution was assigned to week 53, outside the valid 0 to 52 columns. This left the game grid empty and caused four date-dependent Pacman tests to skip the movement and collision behavior they were intended to verify.

## Impact

Current-Sunday contributions now appear in the final grid column. The existing Monday-through-Saturday boundaries remain unchanged.

## Validation

- Node.js 20.20.2 with pnpm 9.15.4: 52 tests passed and production build succeeded
- Node.js 24.18.0 with pnpm 9.15.4: 52 tests passed and production build succeeded
- Prettier check passed
- git diff check passed