### PR TITLE
Fix Pac-Man state consistency and UTC month labels

### DIFF
--- a/src/pacman/core/game.ts
+++ b/src/pacman/core/game.ts
@@ -233,8 +233,8 @@ const pushSnapshot = (store: StoreType) => {
 const checkCollisions = (store: StoreType) => {
 	if (store.pacman.deadRemainingDuration) return;
 
-	store.ghosts.forEach((ghost) => {
-		if (ghost.name === 'eyes') return;
+	for (const ghost of store.ghosts) {
+		if (ghost.name === 'eyes') continue;
 
 		if (ghost.x === store.pacman.x && ghost.y === store.pacman.y) {
 			if (ghost.scared) {
@@ -252,9 +252,10 @@ const checkCollisions = (store: StoreType) => {
 				if (store.pacman.deadRemainingDuration === 0) {
 					store.pacman.deadRemainingDuration = PACMAN_DEATH_DURATION;
 				}
+				return;
 			}
 		}
-	});
+	}
 };
 
 const releaseGhostFromHouse = (store: StoreType, name: GhostName) => {

--- a/src/pacman/movement/pacman-movement.ts
+++ b/src/pacman/movement/pacman-movement.ts
@@ -280,7 +280,6 @@ const checkAndEatPoint = (store: StoreType) => {
 	if (cell.level !== 'NONE') {
 		store.pacman.totalPoints += cell.commitsCount;
 		store.pacman.points++;
-		store.config.pointsIncreasedCallback(store.pacman.totalPoints);
 
 		const theme = Utils.getCurrentTheme(store);
 		if (cell.level === 'FOURTH_QUARTILE') {
@@ -298,6 +297,8 @@ const checkAndEatPoint = (store: StoreType) => {
 			y: store.pacman.y,
 			color: cell.color
 		});
+
+		store.config.pointsIncreasedCallback(store.pacman.totalPoints);
 	}
 };
 

--- a/src/pacman/tests/game.test.ts
+++ b/src/pacman/tests/game.test.ts
@@ -68,6 +68,24 @@ const mockNextCollision = (scared: boolean) => {
 	jest.spyOn(SVG, 'generateAnimatedSVG').mockReturnValue('<svg/>');
 };
 
+const mockDangerousAndScaredCollision = () => {
+	jest.spyOn(PacmanMovement, 'movePacman').mockImplementation((store) => {
+		const [dangerousGhost, scaredGhost] = store.ghosts;
+		store.pacman.x = dangerousGhost.x;
+		store.pacman.y = dangerousGhost.y;
+		scaredGhost.x = dangerousGhost.x;
+		scaredGhost.y = dangerousGhost.y;
+		dangerousGhost.scared = false;
+		scaredGhost.scared = true;
+		store.grid.flat().forEach((cell) => {
+			cell.commitsCount = 0;
+			cell.level = 'NONE';
+		});
+	});
+	jest.spyOn(GhostsMovement, 'moveGhosts').mockImplementation(() => {});
+	jest.spyOn(SVG, 'generateAnimatedSVG').mockReturnValue('<svg/>');
+};
+
 describe('Pac-Man game completion', () => {
 	afterEach(() => {
 		jest.restoreAllMocks();
@@ -144,5 +162,16 @@ describe('Pac-Man game completion', () => {
 		expect(store.gameHistory[0].pacman.deadRemainingDuration).toBe(PACMAN_DEATH_DURATION);
 		expect(store.pacman.ghostsEaten).toBe(0);
 		expect(store.ghosts[0].name).toBe('blinky');
+	});
+
+	it('stops resolving collisions after Pac-Man dies', async () => {
+		const store = createStore(true);
+		mockDangerousAndScaredCollision();
+
+		await Game.startGame(store);
+
+		expect(store.gameHistory[0].pacman.deadRemainingDuration).toBe(PACMAN_DEATH_DURATION);
+		expect(store.pacman.ghostsEaten).toBe(0);
+		expect(store.ghosts[1].name).toBe('inky');
 	});
 });

--- a/src/pacman/tests/pacman-movement.test.ts
+++ b/src/pacman/tests/pacman-movement.test.ts
@@ -1,0 +1,83 @@
+import { GAME_THEMES, GRID_HEIGHT, GRID_WIDTH } from '../../shared/constants';
+import { PacmanMovement } from '../movement/pacman-movement';
+import { PlayerStyle, StoreType } from '../types';
+import { Grid } from '../utils/grid';
+
+const createStore = (): StoreType => {
+	const emptyColor = GAME_THEMES.github.intensityColors[0];
+	const grid: StoreType['grid'] = Array.from({ length: GRID_WIDTH }, () =>
+		Array.from({ length: GRID_HEIGHT }, () => ({ commitsCount: 0, color: emptyColor, level: 'NONE' as const }))
+	);
+	grid[1][0] = {
+		commitsCount: 7,
+		color: GAME_THEMES.github.intensityColors[1],
+		level: 'FIRST_QUARTILE'
+	};
+
+	return {
+		frameCount: 0,
+		aliveSteps: 0,
+		contributions: [],
+		pacman: {
+			x: 0,
+			y: 0,
+			direction: 'right',
+			points: 0,
+			totalPoints: 0,
+			deadRemainingDuration: 0,
+			powerupRemainingDuration: 0,
+			recentPositions: [],
+			target: { x: 1, y: 0 },
+			ghostsEaten: 0
+		},
+		ghosts: [],
+		grid,
+		monthLabels: Array(GRID_WIDTH).fill(''),
+		pacmanMouthOpen: true,
+		gameInterval: 0,
+		gameHistory: [],
+		initialColors: grid.map((column) => column.map((cell) => cell.color)),
+		cellEvents: [],
+		config: {
+			platform: 'github',
+			username: 'test-user',
+			gameTheme: 'github',
+			githubSettings: { accessToken: '' },
+			playerStyle: PlayerStyle.OPPORTUNISTIC,
+			svgCallback: () => {},
+			gameOverCallback: () => {},
+			pointsIncreasedCallback: jest.fn(() => {
+				throw new Error('callback failed');
+			})
+		},
+		useGithubThemeColor: true
+	};
+};
+
+describe('Pac-Man movement', () => {
+	beforeAll(() => {
+		Grid.buildWalls();
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('finishes consuming a cell when the points callback throws', () => {
+		const store = createStore();
+		jest.spyOn(console, 'error').mockImplementation(() => {});
+
+		PacmanMovement.movePacman(store);
+
+		expect(store.config.pointsIncreasedCallback).toHaveBeenCalledWith(7);
+		expect(store.pacman.totalPoints).toBe(7);
+		expect(store.grid[1][0]).toMatchObject({ commitsCount: 0, level: 'NONE' });
+		expect(store.cellEvents).toEqual([
+			expect.objectContaining({
+				frameIndex: 0,
+				x: 1,
+				y: 0
+			})
+		]);
+	});
+});

--- a/src/shared/utils/utils.test.ts
+++ b/src/shared/utils/utils.test.ts
@@ -45,3 +45,27 @@ describe('buildGrid', () => {
 		});
 	});
 });
+
+describe('buildMonthLabels', () => {
+	afterEach(() => {
+		jest.useRealTimers();
+		jest.restoreAllMocks();
+	});
+
+	it('uses UTC month boundaries regardless of the runtime timezone', () => {
+		const toLocaleString = Date.prototype.toLocaleString;
+		jest.spyOn(Date.prototype, 'toLocaleString').mockImplementation(function (this: Date, locales, options) {
+			return toLocaleString.call(this, locales, {
+				...options,
+				timeZone: options?.timeZone ?? 'America/Los_Angeles'
+			});
+		});
+		jest.useFakeTimers();
+		jest.setSystemTime(SUNDAY);
+		const store = createStore();
+
+		Utils.buildMonthLabels(store);
+
+		expect(store.monthLabels[27]).toBe('Feb');
+	});
+});

--- a/src/shared/utils/utils.ts
+++ b/src/shared/utils/utils.ts
@@ -103,7 +103,7 @@ export const buildMonthLabels = (store: BaseStore) => {
 		const date = new Date(startDate);
 		date.setUTCDate(date.getUTCDate() + week * 7);
 
-		const currentMonth = date.toLocaleString('default', { month: 'short' });
+		const currentMonth = date.toLocaleString('default', { month: 'short', timeZone: 'UTC' });
 		if (currentMonth !== lastMonth) {
 			labels[week] = currentMonth;
 			lastMonth = currentMonth;


### PR DESCRIPTION
## Summary

This PR fixes three independent state-consistency issues found while reviewing Pac-Man behavior.

- Complete the internal cell update before calling `pointsIncreasedCallback`, so a callback exception cannot leave the score and grid out of sync.
- Stop resolving further ghost collisions after Pac-Man dies, so a scared ghost in the same cell is not counted as eaten afterward.
- Format contribution month labels in UTC, so their week positions do not depend on the runner's local timezone.

Each fix includes a regression test that failed against the previous implementation.

## Impact

The changes keep scores, cells, collision results, and month labels internally consistent without changing normal Pac-Man movement behavior.

Seeded simulations showed identical death counts, completion results, and frame counts before and after these three fixes. Experimental ghost timer and pathfinding changes are intentionally not included because they increased deaths in the simulations.

## Validation

- `mise exec node@24.18.0 -- pnpm test -- --runInBand` (55 tests passed)
- Production webpack build with Node.js 24.18.0
- Seeded single-game and concurrent-game comparisons

## Context

This branch is rebased onto `main` after #31 was merged and now contains only the three fixes described above.
