### PR TITLE
Harden release workflow against partial releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ on:
           - minor
           - major
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -22,10 +26,18 @@ jobs:
       id-token: write
 
     steps:
+      - name: Verify release branch
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "::error::Releases must be dispatched from main, not $GITHUB_REF."
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
@@ -40,54 +52,172 @@ jobs:
       - name: Install root dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Bump root package version
+      - name: Resolve release version
         id: version
         run: |
-          NEW_VERSION=$(npm version ${{ inputs.bump }} --no-git-tag-version | sed 's/^v//')
-          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "Bumped to v$NEW_VERSION"
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          CURRENT_TAG="v$CURRENT_VERSION"
+          TAG_COMMIT=$(git rev-list -n 1 "$CURRENT_TAG" 2>/dev/null || true)
+          PUBLISHED_VERSION=$(npm view "pacman-contribution-graph@$CURRENT_VERSION" version 2>/dev/null || true)
+
+          if gh api --silent "repos/$GITHUB_REPOSITORY/releases/tags/$CURRENT_TAG" >/dev/null 2>&1; then
+            RELEASE_EXISTS=true
+          else
+            RELEASE_EXISTS=false
+          fi
+
+          if [ -n "$TAG_COMMIT" ] && { [ "$PUBLISHED_VERSION" != "$CURRENT_VERSION" ] || [ "$RELEASE_EXISTS" != "true" ]; }; then
+            if [ "$TAG_COMMIT" != "$(git rev-parse HEAD)" ]; then
+              echo "::error::$CURRENT_TAG does not point to the current main commit."
+              exit 1
+            fi
+
+            if [ "$(git cat-file -t "$CURRENT_TAG")" != "tag" ]; then
+              echo "::error::$CURRENT_TAG must be an annotated tag."
+              exit 1
+            fi
+
+            NEW_VERSION=$CURRENT_VERSION
+            MODE=resume
+            echo "Resuming incomplete release v$NEW_VERSION."
+          else
+            NEW_VERSION=$(npm version "$BUMP" --no-git-tag-version | sed 's/^v//')
+            if [ "$(npm view "pacman-contribution-graph@$NEW_VERSION" version 2>/dev/null || true)" = "$NEW_VERSION" ]; then
+              echo "::error::pacman-contribution-graph@$NEW_VERSION already exists without a matching incomplete release."
+              exit 1
+            fi
+
+            MODE=new
+            PUBLISHED_VERSION=
+            RELEASE_EXISTS=false
+            echo "Preparing new release v$NEW_VERSION."
+          fi
+
+          npm pkg set --prefix github-action version="$NEW_VERSION"
+          {
+            echo "new_version=$NEW_VERSION"
+            echo "mode=$MODE"
+            echo "npm_published=$([ "$PUBLISHED_VERSION" = "$NEW_VERSION" ] && echo true || echo false)"
+            echo "release_exists=$RELEASE_EXISTS"
+          } >> "$GITHUB_OUTPUT"
+        env:
+          BUMP: ${{ inputs.bump }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify npm authentication
+        if: steps.version.outputs.npm_published != 'true'
+        run: npm whoami
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Run tests
+        run: pnpm test -- --runInBand
+
+      - name: Run Prettier check
+        run: pnpm exec prettier --check "**/*.{ts,json,md}"
 
       - name: Build main package
         run: pnpm build
 
-      - name: Publish main package to npm
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Update github-action package.json
-        run: |
-          VERSION=${{ steps.version.outputs.new_version }}
-          cd github-action
-          npm pkg set version="$VERSION"
-          npm pkg set dependencies.pacman-contribution-graph="$VERSION"
-
       - name: Install github-action dependencies
-        # Retry until the newly published version propagates on the npm registry
-        run: |
-          VERSION=${{ steps.version.outputs.new_version }}
-          cd github-action
-          for i in $(seq 1 12); do
-            echo "Attempt $i: installing pacman-contribution-graph@$VERSION..."
-            pnpm install --no-frozen-lockfile && break
-            echo "Not available yet. Waiting 15s..."
-            sleep 15
-          done
+        run: pnpm install --dir github-action --frozen-lockfile
 
       - name: Build github-action
         run: pnpm run --prefix ./github-action build
 
-      - name: Commit, tag, and push release
+      - name: Validate release artifacts
         run: |
-          VERSION=${{ steps.version.outputs.new_version }}
+          test -s dist/pacman-contribution-graph.min.js
+          test -s github-action/dist/index.js
+          node --check github-action/dist/index.js
+          git diff --check
+
+          if [ "$RELEASE_MODE" = "resume" ] && ! git diff --quiet -- package.json dist/pacman-contribution-graph.min.js github-action/package.json github-action/dist/index.js; then
+            echo "::error::The prepared release artifacts are not reproducible from the tagged source."
+            git diff --stat
+            exit 1
+          fi
+        env:
+          RELEASE_MODE: ${{ steps.version.outputs.mode }}
+
+      - name: Pack release artifact
+        id: package
+        run: |
+          PACK_OUTPUT=$(npm pack --json --pack-destination "$RUNNER_TEMP")
+          PACKAGE_FILE=$(node -p "JSON.parse(process.argv[1])[0].filename" "$PACK_OUTPUT")
+          PACKAGE_INTEGRITY=$(node -p "JSON.parse(process.argv[1])[0].integrity" "$PACK_OUTPUT")
+
+          if [ "$NPM_PUBLISHED" = "true" ]; then
+            PUBLISHED_INTEGRITY=$(npm view "pacman-contribution-graph@$VERSION" dist.integrity)
+            if [ "$PACKAGE_INTEGRITY" != "$PUBLISHED_INTEGRITY" ]; then
+              echo "::error::The local package does not match pacman-contribution-graph@$VERSION on npm."
+              exit 1
+            fi
+          fi
+
+          {
+            echo "path=$RUNNER_TEMP/$PACKAGE_FILE"
+            echo "integrity=$PACKAGE_INTEGRITY"
+          } >> "$GITHUB_OUTPUT"
+        env:
+          NPM_PUBLISHED: ${{ steps.version.outputs.npm_published }}
+          VERSION: ${{ steps.version.outputs.new_version }}
+
+      - name: Commit, tag, and push release source
+        if: steps.version.outputs.mode == 'new'
+        run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
+          git add package.json dist/pacman-contribution-graph.min.js github-action/package.json github-action/dist/index.js
           git commit -m "chore: release v$VERSION"
-          git tag "v$VERSION"
-          git push origin main --follow-tags
+          git tag -a "v$VERSION" -m "v$VERSION"
+          git push --atomic origin HEAD:refs/heads/main "refs/tags/v$VERSION"
+        env:
+          VERSION: ${{ steps.version.outputs.new_version }}
+
+      - name: Publish main package to npm
+        if: steps.version.outputs.npm_published != 'true'
+        run: |
+          PUBLISHED_VERSION=$(npm view "pacman-contribution-graph@$VERSION" version 2>/dev/null || true)
+          if [ "$PUBLISHED_VERSION" = "$VERSION" ]; then
+            PUBLISHED_INTEGRITY=$(npm view "pacman-contribution-graph@$VERSION" dist.integrity)
+            if [ "$PUBLISHED_INTEGRITY" != "$PACKAGE_INTEGRITY" ]; then
+              echo "::error::pacman-contribution-graph@$VERSION already exists with different contents."
+              exit 1
+            fi
+
+            echo "pacman-contribution-graph@$VERSION is already published with the expected contents."
+          else
+            npm publish "$PACKAGE_PATH" --provenance --access public
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PACKAGE_INTEGRITY: ${{ steps.package.outputs.integrity }}
+          PACKAGE_PATH: ${{ steps.package.outputs.path }}
+          VERSION: ${{ steps.version.outputs.new_version }}
+
+      - name: Verify npm package availability
+        run: |
+          for attempt in $(seq 1 12); do
+            PUBLISHED_VERSION=$(npm view "pacman-contribution-graph@$VERSION" version 2>/dev/null || true)
+            if [ "$PUBLISHED_VERSION" = "$VERSION" ]; then
+              echo "pacman-contribution-graph@$VERSION is available on npm."
+              exit 0
+            fi
+
+            if [ "$attempt" -eq 12 ]; then
+              echo "::error::pacman-contribution-graph@$VERSION was not available after 12 attempts."
+              exit 1
+            fi
+
+            echo "Attempt $attempt: package is not available yet. Waiting 15s..."
+            sleep 15
+          done
+        env:
+          VERSION: ${{ steps.version.outputs.new_version }}
 
       - name: Create GitHub Release
+        if: steps.version.outputs.release_exists != 'true'
         uses: actions/github-script@v8
         with:
           script: |

--- a/github-action/package.json
+++ b/github-action/package.json
@@ -1,12 +1,13 @@
 {
 	"name": "@pacman-contribution-graph/action",
 	"version": "5.3.1",
+	"private": true,
 	"scripts": {
 		"build": "ncc build src/index.js -o dist"
 	},
 	"dependencies": {
 		"@actions/core": "1.10.1",
-		"pacman-contribution-graph": "5.3.1"
+		"pacman-contribution-graph": "file:.."
 	},
 	"devDependencies": {
 		"@vercel/ncc": "^0.38.3"

--- a/github-action/pnpm-lock.yaml
+++ b/github-action/pnpm-lock.yaml
@@ -11,8 +11,8 @@ importers:
                 specifier: 1.10.1
                 version: 1.10.1
             pacman-contribution-graph:
-                specifier: 5.3.1
-                version: 5.3.1
+                specifier: file:..
+                version: file:..
         devDependencies:
             '@vercel/ncc':
                 specifier: ^0.38.3
@@ -60,8 +60,8 @@ packages:
         resolution: { integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ== }
         engines: { node: '>=18' }
 
-    pacman-contribution-graph@5.3.1:
-        resolution: { integrity: sha512-1rfD8DocfNjUP+P18EtZUv05C3gQklBiNyzscW8Tl+DP8UEfRT7y3mS3VzwUcVpVB3+g6h0zFpmsHd18msAs7A== }
+    pacman-contribution-graph@file:..:
+        resolution: { directory: .., type: directory }
         hasBin: true
 
     string-width@7.2.0:
@@ -133,7 +133,7 @@ snapshots:
 
     get-east-asian-width@1.3.0: {}
 
-    pacman-contribution-graph@5.3.1:
+    pacman-contribution-graph@file:..:
         dependencies:
             yargs: 18.0.0
 


### PR DESCRIPTION
## Summary

- restrict manual releases to `main` and serialize release runs
- run tests and build both the npm package and GitHub Action before publishing
- build the Action from the local root package instead of waiting for npm propagation
- create and push the release commit and annotated tag atomically
- safely resume an incomplete tagged release and verify npm tarball integrity

## Root cause

The previous workflow published to npm before the Action bundle, release commit, tag, and GitHub Release were ready. A failure after `npm publish` could therefore leave an immutable npm version without matching GitHub artifacts. It also relied on a `GITHUB_TOKEN` push to run normal CI, created a lightweight tag that `--follow-tags` would not push, and allowed the registry retry loop to finish without a successful install.

This change prepares and validates all build artifacts first. The source commit and annotated tag are then pushed together before publishing the already packed tarball. If npm publishing or GitHub Release creation fails afterward, the next manual run resumes the same tagged version and only skips an existing npm publish when its integrity matches.

The workflow remains `workflow_dispatch` only, so merging this PR does not bump or publish a version.

## Validation

- 7 Jest suites and 52 tests pass on Node.js 24 and pnpm 9.15.4
- root TypeScript check and webpack build pass
- GitHub Action frozen install, `ncc` build, and generated bundle syntax check pass
- Prettier, actionlint, ShellCheck, and `git diff --check` pass
- new-release and interrupted-release resume paths were simulated locally

## References

- [GitHub Actions concurrency](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency)
- [Workflow runs triggered by `GITHUB_TOKEN`](https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs)
- [`git push --atomic` and `--follow-tags`](https://git-scm.com/docs/git-push)
- [`npm publish` package integrity and immutable versions](https://docs.npmjs.com/cli/v11/commands/npm-publish)
- [pnpm local `file:` dependencies](https://pnpm.io/cli/link)

Closes #32
